### PR TITLE
allow overriding post link in nodeToFeedItem

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ module.exports = (api, options) => {
       // items that may not get included in the feed, but it's build time, so... ¯\_(ツ)_/¯
       const items = collection.data.filter(options.filterNodes).map(node => {
         const feedItem = options.nodeToFeedItem(node)
-        feedItem.id = urlWithBase(pathPrefix + node.path, siteUrl, options.enforceTrailingSlashes)
-        feedItem.link = feedItem.id
+        feedItem.link = feedItem.link || urlWithBase(pathPrefix + node.path, siteUrl, options.enforceTrailingSlashes)
+        feedItem.id = feedItem.link
         return feedItem
       })
 


### PR DESCRIPTION
right now the plugin assumes that the posts are served at the same path that they are stored. this doesn't necessarily have to be the case. 
this fix allows providing `link` in the `nodeToFeedItem` function in gridsome.config.js, and matches the linked example https://github.com/jpmonette/feed#example which also has a link field.