### PR TITLE
fix: output filename for atom and json

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,12 +126,12 @@ module.exports = (api, options) => {
 
     if (atomOutput) {
       console.log(`Generate Atom feed at ${atomOutput}`)
-      writeFile(config.outputDir, rssOutput, feed.atom1())
+      writeFile(config.outputDir, atomOutput, feed.atom1())
     }
 
     if (jsonOutput) {
       console.log(`Generate JSON feed at ${jsonOutput}`)
-      writeFile(config.outputDir, rssOutput, feed.json1())
+      writeFile(config.outputDir, jsonOutput, feed.json1())
     }
   })
 }


### PR DESCRIPTION
Seems like a typo, current version of this library outputs all three formatted feeds into the same file. Simple modifications could be applied to fix this. :heart: Happy new year!